### PR TITLE
Don't use <abbr> in <title> tag

### DIFF
--- a/src/visualization.html
+++ b/src/visualization.html
@@ -1,5 +1,5 @@
 ---
-title: Visualization of <abbr title="Operational Transformation">OT</abbr> with a central server
+title: Visualization of OT with a central server
 ---
 
 <div class="container" id="wrapper">


### PR DESCRIPTION
According to http://www.w3.org/TR/2011/WD-html5-author-20110705/the-title-element.html, a &lt;title&gt; tag may only contain text. Also, without this fix, my browser shows unsightly HTML code in the title bar.

By the way, the dynamic visualization is really awsome!